### PR TITLE
Use GitHub Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,25 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: PScribo Version
+      description: Run `Get-InstalledModule | Out-String | Set-Clipboard` and paste the value here
+      render: PowerShell
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: PowerShell Version
+      description: Run `$PSVersionTable | Out-String | Set-Clipboard` and paste the value here
+      render: PowerShell
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,10 @@
+name: Feature Request
+description: File a feature request.
+title: "[Feature Request]: "
+labels: ["feature-request"]
+body:
+  - type: textarea
+    attributes:
+      label: What feature would you like implemented?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
This PR is to enable Issue Templates.
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates

You will need to add the `bug` and `feature-request` labels to issues for them to automatically be added to future submissions.